### PR TITLE
Updated list of yt-dlp fields

### DIFF
--- a/params/params_metadata.ini
+++ b/params/params_metadata.ini
@@ -11,6 +11,7 @@ _int = _int_test
        _redis_port
        age_limit
        buffersize
+       concurrent_fragment_downloads
        extractor_retries
        http_chunk_size
        max_filesize
@@ -48,14 +49,10 @@ _bool = _allow_dangerous_post_requests
         call_home
         check_formats
         clean_infojson
-        concurrent_fragment_downloads
         continuedl
         debug_printtraffic
-        download_archive
         dynamic_mpd
         extract_flat
-        file_access_retries
-        fixup
         force_generic_extractor
         force_write_download_archive
         forcedescription
@@ -66,7 +63,6 @@ _bool = _allow_dangerous_post_requests
         forcetitle
         forceurl
         format_sort_force
-        fragment_retries
         geo_bypass
         getcomments
         hls_prefer_native
@@ -81,7 +77,6 @@ _bool = _allow_dangerous_post_requests
         listformats
         listsubtitles
         mark_watched
-        merge_output_format
         no_color
         no_warnings
         nocheckcertificate
@@ -96,14 +91,12 @@ _bool = _allow_dangerous_post_requests
         prefer_free_formats
         prefer_insecure
         quiet
-        quiet
         restrictfilenames
         simulate
         skip_download
         updatetime
         usenetrc
         verbose
-        wait_for_video
         windowsfilenames
         write_all_thumbnails
         writeannotations


### PR DESCRIPTION
This moves `concurrent_fragment_downloads` and `wait_for_video` from bool to int, removes `download_archive`, `file_access_retries`, `fixup`, `fragment_retries`, `merge_output_format` from bool list, as they either require a string or allows a string, e.g. `infinite` retries. Also removes a duplicate `quiet`. 