### PR TITLE
Rework dockerfile, entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,25 +4,46 @@ echo ~~~ ydl_api_ng
 echo ~~~ Revision : $GIT_BRANCH - $GIT_REVISION
 echo ~~~ Docker image generated : $DATE
 
-mkdir -p /app/logs /app/downloads /app/params /app/tmp /home/ydl_api_ng /app/data /root/yt-dlp-plugins /app/cookies/
-cp -n /app/setup/* /app/params/
-touch /app/data/database.json
-ln -s /app/data/database.json ./database.json
+mkdir -p /app/logs /app/downloads /app/params /app/tmp /app/data /root/yt-dlp-plugins /app/cookies/
+
+getent group $GID > /dev/null
+if [ $? -eq 0 ]; then
+  groupmod $(id --name --group $GID) -n ydl_api_ng
+else
+  addgroup --gid $GID ydl_api_ng
+fi
+
+getent passwd $UID > /dev/null
+if [ $? -eq 0 ]; then
+  usermod $(id --name --user $UID) -l ydl_api_ng
+
+else
+  useradd -m --uid $UID --gid ydl_api_ng ydl_api_ng
+fi
+
+chown -R $UID:$GID /app
+chown $UID:$GID /home/ydl_api_ng /root/yt-dlp-plugins
+chmod a+x /root/ entrypoint.sh
+
+# If paraps.ini exists, assume setup has been run. Don't copy extra files the user may have removed.
+if [ ! -e '/app/params/params.ini' ]; then
+ cp -n /app/setup/* /app/params/
+fi
+
+# Just access the file from the correct place in the app
+if [ ! -e /app/data/database.json ]; then
+ touch /app/data/database.json
+fi
 
 if [ "$FORCE_YTDLP_VERSION" == "" ]; then
   echo --- Upgrade yt-dlp to the latest version ---
-  pip3 install yt-dlp --upgrade
+  pip3 install yt-dlp --upgrade --disable-pip-version-check -q --root-user-action=ignore
 else
   echo --- Force yt-dlp version $FORCE_YTDLP_VERSION ---
-  pip3 install yt-dlp==$FORCE_YTDLP_VERSION --force-reinstall
+  pip3 install --disable-pip-version-check -q --root-user-action=ignore yt-dlp==$FORCE_YTDLP_VERSION --force-reinstall
 fi
 
-pip3 install -r /app/params/hooks_requirements
-
-addgroup --gid $GID ydl_api_ng && useradd --uid $UID --gid ydl_api_ng ydl_api_ng
-
-chown $UID:$GID /app/logs /app/downloads /home/ydl_api_ng /app/tmp /app/data /app/data/database.json /app/cookies /root/yt-dlp-plugins
-chmod a+x /root/ entrypoint.sh
+pip3 install --disable-pip-version-check -q --root-user-action=ignore -r /app/params/hooks_requirements
 
 if [ "$DISABLE_REDIS" == "false" ]; then
   cat <<EOT >>/app/supervisord_workers.conf

--- a/programmation_persistence_manager.py
+++ b/programmation_persistence_manager.py
@@ -5,7 +5,7 @@ from programmation_class import Programmation
 
 class ProgrammationPersistenceManager:
     def __init__(self, database_file=None, *args, **kwargs):
-        self.__database_file = database_file if database_file is not None else 'database.json'
+        self.__database_file = database_file if database_file is not None else 'data/database.json'
 
         self.__db = TinyDB(self.__database_file)
         self.__scheduled_jobs_table = self.__db.table('scheduled_jobs', cache_size=0)


### PR DESCRIPTION
As mentioned in #20.

Preface: This is not to sound like a lecture. I'm merely explaining the rationale, please don't take offense or feel spoken down to.

Docker images exist as layers. Re-using layers saves speed and time. Keep changes within the container absolutely minimal for optimal size.

Changed to a non-point-release image, so supplemental bugfixes are carried into this image, rather than fixing to the .1 point-release of Python 3.12 -- odds of breaking between 3.12.1 and 3.12.x are extremely minimal but bugfixes might matter.

Installing `gcc, g++, python3-dev` installs A LOT of libraries, dependencies, etc which are wholly not necessary for this app. Somehow even xorg stuff was getting pulled in. None of this is required. The container should only house necessary files. `gcc` and `g++` are used by python __in unsupported environments__ to build wheels. The `python:x` docker container is explicitly the most supported environment they have. `python3-dev` is only for users wishing to do development OF Python3 -- development targetting the internals of python3 or creation of Python extensions explicitly, not development of applications using python3 as a platform.

Installing `dos2unix` is not necessary if you just write the files correctly in the first place. Might not even be necessary at all. If you don't want to write the files correctly in the first place and must fix them as the image is built instead to work around deficiencies in your environment, let me know and I can rewrite this so dos2unix is not needlessly installed __in the container__ but is instead merely used on the files before they're copied. The container should only house files necessary for the container to run. If you're using this because your repo is configured incorrectly and enforcing the wrong line endings, see [https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings]

Rather than installing ffmpeg from apt (and all the bloat that pulls in, as well as the cleanup we must do afterward) we're pulling the Python package static-ffmpeg which is the minimalist way to install static builds of ffmpeg on any* system. (Static binaries run without *ANY* libraries and are the slimmest, lowest-footprint way to go.)

Changing the entrypoint from `CMD` to `ENTRYPOINT` is really a bit of a preferential bias.

The `VOLUME` and `EXPOSE` keywords indicate to container management software how the container is intended to be "hooked up" so to speak. Not necessary, but nice.

I've moved UID/GID stuff to the top of the entrypoint, so that's all correct before we start using it.

Re-copying the `setup` files re-copies the examples and all of the other files, which some users might not need in their configuration, so we check first during the entrypoint.

For pip, `--disable-pip-version-check -q --root-user-action=ignore` is just to make pip complain less in the logs, so you see mostly valid information instead of a bunch of extra stuff.

Please test and verify before accepting the pull, I've looked at most things but I'm not positive I caught absolutely every edge case here. Definitely ask questions or request changes if you need them.
